### PR TITLE
Show page: Remove btn class from back-to-search

### DIFF
--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -1,0 +1,12 @@
+<% if current_search_session %>
+  <div id="appliedParams" class="clearfix constraints-container">
+    <%= link_to t('blacklight.search.start_over'), start_over_path, class: "catalog_startOverLink btn btn-primary" %>
+    <%= link_back_to_catalog class: 'btn-outline-secondary' %>
+  </div>
+<% end %>
+
+<%= render_document_main_content_partial %>
+
+<% content_for(:sidebar) do %>
+  <%= render_document_sidebar_partial %>
+<% end %>


### PR DESCRIPTION
**will look like:**
![Screen Shot 2020-01-24 at 10 01 04 AM](https://user-images.githubusercontent.com/9905193/73078593-7c4f3580-3e90-11ea-8f2f-3c321435fc7c.png)

**vs:**
![Screen Shot 2020-01-24 at 10 02 08 AM](https://user-images.githubusercontent.com/9905193/73078657-9ab53100-3e90-11ea-90d4-5d7e6d512bac.png)
